### PR TITLE
Developer Experience: improve clangd support

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -175,6 +175,8 @@ config.reconfig_deps = []
 # Can be overridden in libraries or objects
 config.scratch_preset_id = None
 
+config.extra_clang_flags = ["-D__INTELLISENSE__"]
+
 # Base flags, common to most GC/Wii games.
 # Generally leave untouched, with overrides added below.
 cflags_base = [

--- a/include/macros.h
+++ b/include/macros.h
@@ -16,17 +16,32 @@
 
 #define ARRAY_SIZE(x) (sizeof((x)) / sizeof((x)[0]))
 
-#define MEMCLR(x) __memclr((x), sizeof(*(x)))
-
 #define ALIGN(x) __attribute__((aligned(x)))
 
 #define DECL_SECTION(x) __declspec(section x)
 #define DECL_WEAK __declspec(weak)
 
+#ifdef __MWERKS__
+
 #define DECLTYPE(x) __decltype__(x)
+#define MEMCLR(x) __memclr((x), sizeof(*(x)))
+#define ARRAY_AT_ADDRESS(addr) [] : (addr)
+#define AT_ADDRESS(addr) : (addr)
+#define PPC_ASM asm
 
 // For VSCode
-#ifdef __INTELLISENSE__
+#elif defined(__INTELLISENSE__)
+#ifdef __clang__ 
+    #define MEMCLR(x) __builtin_memset((x), 0, sizeof(*(x)));
+    #define DECLTYPE(x) __decltype(x)
+#endif
+// 'Zero Size Array' hack to avoid incomplete type like `u8 foo[];`. 
+// the real fix is to make the AT_ADDRESS macro work in clang.
+#define ARRAY_AT_ADDRESS(addr) [0]
+#define AT_ADDRESS(addr)
+// this macro was created with the following regex:
+// search `asm \{([^{}]*\n?)*\}` replace `PPC_ASM ($1)`
+#define PPC_ASM(...)
 #define asm
 #define __attribute__(x)
 #define __declspec(x)

--- a/include/nw4r/g3d/platform/g3d_cpu.h
+++ b/include/nw4r/g3d/platform/g3d_cpu.h
@@ -45,9 +45,9 @@ inline f32 S7_8ToF32(register const s16* pPtr) {
     register f32 f;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_l f, 0(pPtr), 1, 7
-    }
+    )
     // clang-format on
 
     return f;
@@ -57,9 +57,9 @@ inline f32 S10_5ToF32(register const s16* pPtr) {
     register f32 f;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_l f, 0(pPtr), 1, 6
-    }
+    )
     // clang-format on
 
     return f;
@@ -81,9 +81,9 @@ inline s16 F32ToS10_5(register f32 f) {
     register s16* pPtr = &x;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_st f, 0(pPtr), 1, 6
-    }
+    )
     // clang-format on
 
     return x;

--- a/include/nw4r/g3d/res/g3d_rescommon.h
+++ b/include/nw4r/g3d/res/g3d_rescommon.h
@@ -85,49 +85,49 @@ public:
         return *mpData;
     }
 
-    template <typename T> T* ofs_to_ptr_raw(s32 ofs) {
-        return reinterpret_cast<T*>((char*)mpData + ofs);
+    template <typename U> U* ofs_to_ptr_raw(s32 ofs) {
+        return reinterpret_cast<U*>((char*)mpData + ofs);
     }
-    template <typename T> const T* ofs_to_ptr_raw(s32 ofs) const {
-        return reinterpret_cast<const T*>((char*)mpData + ofs);
+    template <typename U> const U* ofs_to_ptr_raw(s32 ofs) const {
+        return reinterpret_cast<const U*>((char*)mpData + ofs);
     }
 
-    template <typename T> T* ofs_to_ptr(s32 ofs) {
+    template <typename U> U* ofs_to_ptr(s32 ofs) {
         u8* pPtr = reinterpret_cast<u8*>(mpData);
 
         if (ofs != 0) {
-            return reinterpret_cast<T*>(pPtr + ofs);
+            return reinterpret_cast<U*>(pPtr + ofs);
         }
 
         return NULL;
     }
-    template <typename T> const T* ofs_to_ptr(s32 ofs) const {
+    template <typename U> const U* ofs_to_ptr(s32 ofs) const {
         const u8* pPtr = reinterpret_cast<const u8*>(mpData);
 
         if (ofs != 0) {
-            return reinterpret_cast<const T*>(pPtr + ofs);
+            return reinterpret_cast<const U*>(pPtr + ofs);
         }
 
         return NULL;
     }
 
-    template <typename T> T ofs_to_obj(s32 ofs) {
+    template <typename U> U ofs_to_obj(s32 ofs) {
         u8* pPtr = reinterpret_cast<u8*>(mpData);
 
         if (ofs != 0) {
-            return T(pPtr + ofs);
+            return U(pPtr + ofs);
         }
 
-        return T(NULL);
+        return U(NULL);
     }
-    template <typename T> const T ofs_to_obj(s32 ofs) const {
+    template <typename U> const U ofs_to_obj(s32 ofs) const {
         const u8* pPtr = reinterpret_cast<const u8*>(mpData);
 
         if (ofs != 0) {
-            return T(const_cast<u8*>(pPtr + ofs));
+            return U(const_cast<u8*>(pPtr + ofs));
         }
 
-        return T(NULL);
+        return U(NULL);
     }
 
 private:

--- a/include/nw4r/math/math_arithmetic.h
+++ b/include/nw4r/math/math_arithmetic.h
@@ -34,9 +34,9 @@ inline f32 FAbs(register f32 x) {
     register f32 ax;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         fabs ax, x
-    }
+    )
     // clang-format on
 
     return ax;
@@ -58,7 +58,7 @@ inline f32 FInv(register f32 x) {
     register f32 work0, work1, work2, work3;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         fmr  work1, x     // x
         fres work0, work1 // 1/x
 
@@ -66,7 +66,7 @@ inline f32 FInv(register f32 x) {
         ps_add   work2, work0, work0        // 2/x
         ps_mul   work3, work0, work0        // 1/x^2
         ps_nmsub work0, work1, work3, work2 // -(x * 1/x^2 - 2/x)
-    }
+    )
     // clang-format on
 
     return work0;
@@ -97,9 +97,9 @@ inline f32 FSelect(register f32 value, register f32 ge_zero,
     register f32 ret;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         fsel ret, value, ge_zero, lt_zero
-    }
+    )
     // clang-format on
 
     return ret;

--- a/include/nw4r/math/math_types.h
+++ b/include/nw4r/math/math_types.h
@@ -317,7 +317,7 @@ inline VEC3* VEC3Add(register VEC3* pOut, register const VEC3* pA,
     register f32 work0, work1, work2;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         // Add XY
         psq_l  work0, VEC3.x(pA),   0, 0
         psq_l  work1, VEC3.x(pB),   0, 0
@@ -329,7 +329,7 @@ inline VEC3* VEC3Add(register VEC3* pOut, register const VEC3* pA,
         psq_l  work1, VEC3.z(pB),   1, 0
         ps_add work2, work0, work1
         psq_st work2, VEC3.z(pOut), 1, 0
-    }
+    )
     // clang-format on
 
     return pOut;
@@ -340,7 +340,7 @@ inline f32 VEC3Dot(register const VEC3* pA, register const VEC3* pB) {
     register f32 work0, work1, work2, work3;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         // YZ product
         psq_l  work0, VEC3.y(pA), 0, 0
         psq_l  work1, VEC3.y(pB), 0, 0
@@ -353,7 +353,7 @@ inline f32 VEC3Dot(register const VEC3* pA, register const VEC3* pB) {
         
         // Dot product
         ps_sum0 dot, work1, work0, work0
-    }
+    )
     // clang-format on
 
     return dot;
@@ -363,7 +363,7 @@ inline f32 VEC3LenSq(register const VEC3* pVec) {
     register f32 work0, work1, work2;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         // Square XY
         psq_l  work0, VEC3.x(pVec), 0, 0
         ps_mul work0, work0, work0
@@ -374,7 +374,7 @@ inline f32 VEC3LenSq(register const VEC3* pVec) {
 
         // Sum products
         ps_sum0 work2, work2, work0, work0
-    }
+    )
     // clang-format on
 
     return work2;
@@ -385,7 +385,7 @@ inline VEC3* VEC3Lerp(register VEC3* pOut, register const VEC3* pVec1,
     register f32 work0, work1, work2;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         // X/Y delta
         psq_l  work0, VEC3.x(pVec1), 0, 0
         psq_l  work1, VEC3.x(pVec2), 0, 0
@@ -401,7 +401,7 @@ inline VEC3* VEC3Lerp(register VEC3* pOut, register const VEC3* pVec1,
         // Scale with time and add to v0
         ps_madds0 work2, work2, t, work0
         psq_st    work2, VEC3.z(pOut), 1, 0
-    }
+    )
     // clang-format on
 
     return pOut;
@@ -412,7 +412,7 @@ inline VEC3* VEC3Scale(register VEC3* pOut, register const VEC3* pIn,
     register f32 work0, work1;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         // Scale XY
         psq_l    work0, VEC3.x(pIn),  0, 0
         ps_muls0 work1, work0, scale
@@ -422,7 +422,7 @@ inline VEC3* VEC3Scale(register VEC3* pOut, register const VEC3* pIn,
         psq_l    work0, VEC3.z(pIn),  1, 0
         ps_muls0 work1, work0, scale
         psq_st   work1, VEC3.z(pOut), 1, 0
-    }
+    )
     // clang-format on
 
     return pOut;
@@ -433,7 +433,7 @@ inline VEC3* VEC3Sub(register VEC3* pOut, register const VEC3* pA,
     register f32 work0, work1, work2;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         // Sub XY
         psq_l  work0, VEC3.x(pA),   0, 0
         psq_l  work1, VEC3.x(pB),   0, 0
@@ -445,7 +445,7 @@ inline VEC3* VEC3Sub(register VEC3* pOut, register const VEC3* pA,
         psq_l  work1, VEC3.z(pB),   1, 0
         ps_sub work2, work0, work1
         psq_st work2, VEC3.z(pOut), 1, 0
-    }
+    )
     // clang-format on
 
     return pOut;

--- a/include/nw4r/ut/ut_algorithm.h
+++ b/include/nw4r/ut/ut_algorithm.h
@@ -32,9 +32,9 @@ template <> f32 inline Abs(register f32 x) {
     register f32 ax;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         fabs ax, x
-    }
+    )
     // clang-format on
 
     return ax;

--- a/include/revolution/AI/ai_hardware.h
+++ b/include/revolution/AI/ai_hardware.h
@@ -8,7 +8,7 @@ extern "C" {
 /**
  * AI hardware registers
  */
-volatile u32 AI_HW_REGS[] : 0xCD006C00;
+volatile u32 AI_HW_REGS ARRAY_AT_ADDRESS(0xCD006C00);
 
 /**
  * Hardware register indexes

--- a/include/revolution/DSP/dsp_hardware.h
+++ b/include/revolution/DSP/dsp_hardware.h
@@ -8,7 +8,7 @@ extern "C" {
 /**
  * DSP hardware registers
  */
-volatile u16 DSP_HW_REGS[] : 0xCC005000;
+volatile u16 DSP_HW_REGS ARRAY_AT_ADDRESS(0xCC005000);
 
 /**
  * Hardware register indexes

--- a/include/revolution/EXI/EXIHardware.h
+++ b/include/revolution/EXI/EXIHardware.h
@@ -14,7 +14,7 @@ typedef struct EXIChannelParam {
     u32 data;   // at 0x10
 } EXIChannelParam;
 
-volatile EXIChannelParam EXI_CHAN_PARAMS[EXI_MAX_CHAN] : 0xCD006800;
+volatile EXIChannelParam EXI_CHAN_PARAMS[EXI_MAX_CHAN] AT_ADDRESS(0xCD006800);
 
 // CPR - Channel Parameter Register
 #define EXI_CPR_EXIINTMASK (1 << 0)

--- a/include/revolution/GX/GXHardware.h
+++ b/include/revolution/GX/GXHardware.h
@@ -43,7 +43,7 @@ extern volatile union {
     unsigned int ui;
     void* p;
     float f;
-} WGPIPE : 0xCC008000;
+} WGPIPE AT_ADDRESS(0xCC008000);
 
 /**
  * FIFO commands

--- a/include/revolution/IPC/ipcHardware.h
+++ b/include/revolution/IPC/ipcHardware.h
@@ -8,8 +8,8 @@ extern "C" {
 /**
  * IPC hardware registers
  */
-volatile u32 IPC_HW_REGS_PPC[] : 0xCD000000;
-volatile u32 IPC_HW_REGS[] : 0xCD800000;
+volatile u32 IPC_HW_REGS_PPC ARRAY_AT_ADDRESS(0xCD000000);
+volatile u32 IPC_HW_REGS ARRAY_AT_ADDRESS(0xCD800000);
 
 /**
  * Hardware register indexes

--- a/include/revolution/OS/OSFastCast.h
+++ b/include/revolution/OS/OSFastCast.h
@@ -12,7 +12,7 @@ extern "C" {
 
 static void OSInitFastCast(void) {
     // clang-format off
-    asm {
+    PPC_ASM (
         li r3, 4
         oris r3, r3, 4
         mtspr 0x392, r3
@@ -28,7 +28,7 @@ static void OSInitFastCast(void) {
         li r3, 7
         oris r3, r3, 7
         mtspr 0x395, r3
-    }
+    )
     // clang-format on
 }
 
@@ -36,9 +36,9 @@ static void OSSetGQR6(register u32 type, register u32 scale) {
     register u32 val = ((scale << 8 | type) << 16) | ((scale << 8) | type);
 
     // clang-format off
-    asm {
+    PPC_ASM (
         mtspr 0x396, val
-    }
+    )
     // clang-format on
 }
 
@@ -46,9 +46,9 @@ static void OSSetGQR7(register u32 type, register u32 scale) {
     register u32 val = ((scale << 8 | type) << 16) | ((scale << 8) | type);
 
     // clang-format off
-    asm {
+    PPC_ASM (
         mtspr 0x397, val
-    }
+    )
     // clang-format on
 }
 
@@ -61,9 +61,9 @@ static f32 __OSu8tof32(register u8* in) {
     register f32 ret;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_l ret, 0(in), 1, 2
-    }
+    )
     // clang-format on
 
     return ret;
@@ -82,9 +82,9 @@ static f32 __OSu16tof32(register u16* arg) {
     register f32 ret;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_l ret, 0(arg), 1, 3
-    }
+    )
     // clang-format on
 
     return ret;
@@ -103,9 +103,9 @@ static f32 __OSs16tof32(register s16* arg) {
     register f32 ret;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_l ret, 0(arg), 1, 5
-    }
+    )
     // clang-format on
 
     return ret;
@@ -126,9 +126,9 @@ static u8 __OSf32tou8(register f32 arg) {
     u8 r;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_st arg, 0(ptr), 1, 2
-    }
+    )
     // clang-format on
 
     r = *(u8*)ptr;
@@ -145,9 +145,9 @@ static u16 __OSf32tou16(register f32 arg) {
     u16 r;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_st arg, 0(ptr), 1, 3
-    }
+    )
     // clang-format on
 
     r = *(u16*)ptr;
@@ -164,9 +164,9 @@ static s16 __OSf32tos16(register f32 arg) {
     s16 r;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_st arg, 0(ptr), 1, 5
-    }
+    )
     // clang-format on
 
     r = *(s16*)ptr;

--- a/include/revolution/SI/SIHardware.h
+++ b/include/revolution/SI/SIHardware.h
@@ -8,7 +8,7 @@ extern "C" {
 /**
  * SI hardware registers
  */
-volatile u32 SI_HW_REGS[] : 0xCD006400;
+volatile u32 SI_HW_REGS ARRAY_AT_ADDRESS(0xCD006400);
 
 /**
  * Hardware register indexes

--- a/include/revolution/VI/vihardware.h
+++ b/include/revolution/VI/vihardware.h
@@ -8,7 +8,7 @@ extern "C" {
 /**
  * VI hardware registers
  */
-volatile u16 VI_HW_REGS[] : 0xCC002000;
+volatile u16 VI_HW_REGS ARRAY_AT_ADDRESS(0xCC002000);
 
 /**
  * Hardware register indexes

--- a/src/nw4r/g3d/g3d_calcview.cpp
+++ b/src/nw4r/g3d/g3d_calcview.cpp
@@ -142,7 +142,7 @@ inline void SetMdlViewMtxSR(register math::MTX34* pViewPos,
     register f32 c_zero = 0.0f;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_l      work0,  VEC3.x(rRY), 0, 0
         ps_muls0   work0,  work0, s
         ps_merge10 work1,  work0, work0
@@ -154,7 +154,7 @@ inline void SetMdlViewMtxSR(register math::MTX34* pViewPos,
         stfs       c_zero, MTX34._12(pViewPos)
         psq_st     c_zero, MTX34._20(pViewPos), 0, 0
         stfs       s,      MTX34._22(pViewPos)
-    }
+    )
     // clang-format on
 }
 
@@ -166,7 +166,7 @@ inline void SetMdlViewMtxSR(register math::MTX34* pViewPos,
     register f32 c_zero = 0.0f;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         ps_merge00 work0,  sx, sy
         psq_l      work1,  VEC3.x(rRY), 0, 0
         ps_merge10 work3,  work1, work1
@@ -180,7 +180,7 @@ inline void SetMdlViewMtxSR(register math::MTX34* pViewPos,
         stfs       c_zero, MTX34._12(pViewPos)
         psq_st     c_zero, MTX34._20(pViewPos), 0, 0
         stfs       sz,     MTX34._22(pViewPos)
-    }
+    )
     // clang-format on
 }
 
@@ -193,7 +193,7 @@ inline void SetMdlViewMtxSR(register math::MTX34* pViewPos,
     register f32 work0, work1, work2, work3;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_l      work0, VEC3.x(rRX), 0, 0
         psq_l      work1, VEC3.x(rRY), 0, 0
         ps_muls0   work0, work0, sx
@@ -216,7 +216,7 @@ inline void SetMdlViewMtxSR(register math::MTX34* pViewPos,
         lfs        work0, VEC3.z(rRZ)
         fmuls      work0, work0, sz
         stfs       work0, MTX34._22(pViewPos)
-    }
+    )
     // clang-format on
 }
 

--- a/src/nw4r/g3d/g3d_calcvtx.cpp
+++ b/src/nw4r/g3d/g3d_calcvtx.cpp
@@ -83,12 +83,12 @@ void CalcVtx(ResMdl mdl, AnmObjShp* pAnmShp, ResVtxPosData** ppVtxPosTable,
                 register const void* pVtx = rFirst.pVtx;
 
                 // clang-format off
-                asm {
+                PPC_ASM (
                     psq_l  xy, VEC3.x(pVtx), 0, 0
                     psq_l  z_, VEC3.z(pVtx), 1, 0
                     ps_mul xy, xy, firstWeight
                     ps_mul z_, z_, firstWeight
-                }
+                )
                 // clang-format on
 
                 // clang-format off
@@ -102,12 +102,12 @@ void CalcVtx(ResMdl mdl, AnmObjShp* pAnmShp, ResVtxPosData** ppVtxPosTable,
                     register f32 key_xy, key_z_;
 
                     // clang-format off
-                    asm {
+                    PPC_ASM (
                         psq_l   key_xy, VEC3.x(pKeyVtx), 0, 0
                         psq_l   key_z_, VEC3.z(pKeyVtx), 1, 0
                         ps_madd xy, key_xy, keyWeight, xy
                         ps_madd z_, key_z_, keyWeight, z_
-                    }
+                    )
                     // clang-format on
 
                     // clang-format off
@@ -119,10 +119,10 @@ void CalcVtx(ResMdl mdl, AnmObjShp* pAnmShp, ResVtxPosData** ppVtxPosTable,
                 register void* pDst = pVtxPosBuf;
 
                 // clang-format off
-                asm {
+                PPC_ASM (
                     psq_st xy, VEC3.x(pDst), 0, 0
                     psq_st z_, VEC3.z(pDst), 1, 0
-                }
+                )
                 // clang-format on
             }
 
@@ -188,12 +188,12 @@ void CalcVtx(ResMdl mdl, AnmObjShp* pAnmShp, ResVtxPosData** ppVtxPosTable,
                 register const void* pVtx = rFirst.pVtx;
 
                 // clang-format off
-                asm {
+                PPC_ASM (
                     psq_l  xy, VEC3.x(pVtx), 0, 0
                     psq_l  z_, VEC3.z(pVtx), 1, 0
                     ps_mul xy, xy, firstWeight
                     ps_mul z_, z_, firstWeight
-                }
+                )
                 // clang-format on
 
                 // clang-format off
@@ -207,12 +207,12 @@ void CalcVtx(ResMdl mdl, AnmObjShp* pAnmShp, ResVtxPosData** ppVtxPosTable,
                     register f32 key_xy, key_z_;
 
                     // clang-format off
-                    asm {
+                    PPC_ASM (
                         psq_l   key_xy, VEC3.x(pKeyVtx), 0, 0
                         psq_l   key_z_, VEC3.z(pKeyVtx), 1, 0
                         ps_madd xy, key_xy, keyWeight, xy
                         ps_madd z_, key_z_, keyWeight, z_
-                    }
+                    )
                     // clang-format on
 
                     // clang-format off
@@ -224,10 +224,10 @@ void CalcVtx(ResMdl mdl, AnmObjShp* pAnmShp, ResVtxPosData** ppVtxPosTable,
                 register void* pDst = pVtxNrmBuf;
 
                 // clang-format off
-                asm {
+                PPC_ASM (
                     psq_st xy, VEC3.x(pDst), 0, 0
                     psq_st z_, VEC3.z(pDst), 1, 0
-                }
+                )
                 // clang-format on
             }
 
@@ -293,12 +293,12 @@ void CalcVtx(ResMdl mdl, AnmObjShp* pAnmShp, ResVtxPosData** ppVtxPosTable,
                 register const void* pVtx = rFirst.pVtx;
 
                 // clang-format off
-                asm {
+                PPC_ASM (
                     psq_l  rg, Color.r(pVtx), 0, 2
                     psq_l  ba, Color.b(pVtx), 0, 2
                     ps_mul rg, rg, firstWeight
                     ps_mul ba, ba, firstWeight
-                }
+                )
                 // clang-format on
 
                 // clang-format off
@@ -312,12 +312,12 @@ void CalcVtx(ResMdl mdl, AnmObjShp* pAnmShp, ResVtxPosData** ppVtxPosTable,
                     register f32 key_rg, key_ba;
 
                     // clang-format off
-                    asm {
+                    PPC_ASM (
                         psq_l   key_rg, Color.r(pKeyVtx), 0, 2
                         psq_l   key_ba, Color.b(pKeyVtx), 0, 2
                         ps_madd rg, key_rg, keyWeight, rg
                         ps_madd ba, key_ba, keyWeight, ba
-                    }
+                    )
                     // clang-format on
 
                     // clang-format off
@@ -329,10 +329,10 @@ void CalcVtx(ResMdl mdl, AnmObjShp* pAnmShp, ResVtxPosData** ppVtxPosTable,
                 register void* pDst = pVtxClrBuf;
 
                 // clang-format off
-                asm {
+                PPC_ASM (
                     psq_st rg, Color.r(pDst), 0, 2
                     psq_st ba, Color.b(pDst), 0, 2
-                }
+                )
                 // clang-format on
             }
 

--- a/src/nw4r/g3d/g3d_calcworld.cpp
+++ b/src/nw4r/g3d/g3d_calcworld.cpp
@@ -199,14 +199,14 @@ void CalcSkinning(math::MTX34* pModelMtxArray, u32* pModelMtxAttribArray,
             M00 = 0.0f;
 
             // clang-format off
-            asm {
+            PPC_ASM (
                 ps_merge00 M00, M00, M00
                 ps_merge00 M02, M00, M00
                 ps_merge00 M10, M00, M00
                 ps_merge00 M12, M00, M00
                 ps_merge00 M20, M00, M00
                 ps_merge00 M22, M00, M00
-            }
+            )
             // clang-format on
 
             for (u32 i = 0; i < numBlendMtx; i++) {
@@ -227,7 +227,7 @@ void CalcSkinning(math::MTX34* pModelMtxArray, u32* pModelMtxAttribArray,
                 register math::MTX34* pT = &pSkinMtxArray[mtxID];
 
                 // clang-format off
-                asm {
+                PPC_ASM (
                     psq_l T00, MTX34._00(pT), 0, 0
                     psq_l T02, MTX34._02(pT), 0, 0
                     psq_l T10, MTX34._10(pT), 0, 0
@@ -241,7 +241,7 @@ void CalcSkinning(math::MTX34* pModelMtxArray, u32* pModelMtxAttribArray,
                     ps_madds0 M12, T12, R, M12
                     ps_madds0 M20, T20, R, M20
                     ps_madds0 M22, T22, R, M22
-                }
+                )
                 // clang-format on
 
                 pModelMtxAttribArray[targetMtxID] &=
@@ -253,14 +253,14 @@ void CalcSkinning(math::MTX34* pModelMtxArray, u32* pModelMtxAttribArray,
             register math::MTX34* pTargetMtx = &pModelMtxArray[targetMtxID];
 
             // clang-format off
-            asm {
+            PPC_ASM (
                 psq_st M00, MTX34._00(pTargetMtx), 0, 0
                 psq_st M02, MTX34._02(pTargetMtx), 0, 0
                 psq_st M10, MTX34._10(pTargetMtx), 0, 0
                 psq_st M12, MTX34._12(pTargetMtx), 0, 0
                 psq_st M20, MTX34._20(pTargetMtx), 0, 0
                 psq_st M22, MTX34._22(pTargetMtx), 0, 0
-            }
+            )
             // clang-format on
 
         } else /* Assume EVPMTX */ {

--- a/src/nw4r/g3d/g3d_fog.cpp
+++ b/src/nw4r/g3d/g3d_fog.cpp
@@ -38,7 +38,7 @@ Fog Fog::CopyTo(register void* pDst) const {
         register f64 work0, work1, work2, work3, work4, work5;
 
         // clang-format off
-        asm {
+        PPC_ASM (
             lfd  work0, 0(pSrc)
             stfd work0, 0(pDst)
 
@@ -56,7 +56,7 @@ Fog Fog::CopyTo(register void* pDst) const {
 
             lfd  work5, 40(pSrc)
             stfd work5, 40(pDst)
-        }
+        )
         // clang-format on
 
         return Fog(static_cast<FogData*>(pDst));

--- a/src/nw4r/g3d/platform/g3d_cpu.cpp
+++ b/src/nw4r/g3d/platform/g3d_cpu.cpp
@@ -10,7 +10,7 @@ void Copy32ByteBlocks(register void* pDst, register const void* pSrc,
 
     for (size /= 32; size > 0; size--) {
         // clang-format off
-        asm {
+        PPC_ASM (
             lfd  work0, 0(pSrc)
             stfd work0, 0(pDst)
 
@@ -22,7 +22,7 @@ void Copy32ByteBlocks(register void* pDst, register const void* pSrc,
             
             lfd  work3, 24(pSrc)
             stfd work3, 24(pDst)
-        }
+        )
         // clang-format on
 
         pDst = static_cast<u8*>(pDst) + 32;
@@ -35,12 +35,12 @@ void ZeroMemory32ByteBlocks(register void* pDst, register u32 size) {
 
     for (size /= 32; size > 0; size--) {
         // clang-format off
-        asm {
+        PPC_ASM (
             psq_st zero,  0(pDst), 0, 0
             psq_st zero,  8(pDst), 0, 0
             psq_st zero, 16(pDst), 0, 0
             psq_st zero, 24(pDst), 0, 0
-        }
+        )
         // clang-format on
 
         pDst = static_cast<u8*>(pDst) + 32;

--- a/src/nw4r/math/math_arithmetic.cpp
+++ b/src/nw4r/math/math_arithmetic.cpp
@@ -63,7 +63,7 @@ f32 FrSqrt(register f32 x) {
     register f32 work0, work1;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         // Estimate reciprocal square root
         frsqrte rsqrt, x
         
@@ -73,7 +73,7 @@ f32 FrSqrt(register f32 x) {
         fmuls work1, rsqrt, c_half        // rsqrt * 0.5
         fnmsubs work0, work0, x, c_three  // (3 - x * rsqrt^2)
         fmuls work1, work0, work1         // (3 - x * rsqrt^2) * (rsqrt * 0.5)
-    }
+    )
     // clang-format on
 
     return work1;

--- a/src/nw4r/math/math_types.cpp
+++ b/src/nw4r/math/math_types.cpp
@@ -4,13 +4,13 @@
     fx = (_fx);                                                                \
     fy = (_fy);                                                                \
     dt = fx - fy;                                                              \
-    asm { fsel work, dt, fx, fy }
+    PPC_ASM ( fsel work, dt, fx, fy )
 
 #define FSEL_MIN(_fx, _fy)                                                     \
     fx = (_fx);                                                                \
     fy = (_fy);                                                                \
     dt = fy - fx;                                                              \
-    asm { fsel work, dt, fx, fy }
+    PPC_ASM ( fsel work, dt, fx, fy )
 
 namespace nw4r {
 namespace math {
@@ -52,7 +52,7 @@ MTX33* MTX33Identity(register MTX33* pMtx) {
     register f32 c_11;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         ps_merge00 c_11, c_10, c_00
 
         psq_st c_00, MTX33._02(pMtx), 0, 0 // _02=0, _10=0
@@ -61,7 +61,7 @@ MTX33* MTX33Identity(register MTX33* pMtx) {
         psq_st c_11, MTX33._11(pMtx), 0, 0 // _11=1, _12=0
 
         stfs c_10,   MTX33._22(pMtx)       // _22=1
-    }
+    )
     // clang-format on
 
     return pMtx;
@@ -71,7 +71,7 @@ MTX33* MTX34ToMTX33(register MTX33* pOut, register const MTX34* pIn) {
     register f32 row0a, row0b, row1a, row1b, row2a, row2b;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_l row0a, MTX34._00(pIn), 0, 0
         psq_l row0b, MTX34._02(pIn), 0, 0
         psq_l row1a, MTX34._10(pIn), 0, 0
@@ -85,7 +85,7 @@ MTX33* MTX34ToMTX33(register MTX33* pOut, register const MTX34* pIn) {
         psq_st row1b, MTX33._12(pOut), 1, 0
         psq_st row2a, MTX33._20(pOut), 0, 0
         psq_st row2b, MTX33._22(pOut), 1, 0
-    }
+    )
     // clang-format on
 
     return pOut;
@@ -170,14 +170,14 @@ MTX34* MTX34Zero(register MTX34* pMtx) {
     register f32 c_zero = 0.0f;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_st c_zero, MTX34._00(pMtx), 0, 0
         psq_st c_zero, MTX34._02(pMtx), 0, 0
         psq_st c_zero, MTX34._10(pMtx), 0, 0
         psq_st c_zero, MTX34._12(pMtx), 0, 0
         psq_st c_zero, MTX34._20(pMtx), 0, 0
         psq_st c_zero, MTX34._22(pMtx), 0, 0
-    }
+    )
     // clang-format on
 
     return pMtx;
@@ -191,7 +191,7 @@ MTX34* MTX34Scale(register MTX34* pOut, register const MTX34* pIn,
     register f32 row2a, row2b;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_l xy, VEC3.x(pScale), 0, 0 // (XXXX, YYYY)
         psq_l z,  VEC3.z(pScale), 1, 0 // (ZZZZ, 1111)
 
@@ -215,7 +215,7 @@ MTX34* MTX34Scale(register MTX34* pOut, register const MTX34* pIn,
         psq_st row1b, MTX34._12(pOut), 0, 0
         psq_st row2a, MTX34._20(pOut), 0, 0
         psq_st row2b, MTX34._22(pOut), 0, 0
-    }
+    )
     // clang-format on
 
     return pOut;
@@ -230,7 +230,7 @@ MTX34* MTX34Trans(register MTX34* pOut, register const MTX34* pIn,
     register f32 work0, work1, work2;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_l xy, VEC3.x(pTrans), 0, 0 // (XXXX, YYYY)
         psq_l z,  VEC3.z(pTrans), 1, 0 // (ZZZZ, 1111)
 
@@ -270,7 +270,7 @@ MTX34* MTX34Trans(register MTX34* pOut, register const MTX34* pIn,
         ps_madd work1, row2b, z, work0      // (_22*z + _20*x, _23 + _21*y)
         ps_sum0 work2, work1, work2, work1
         psq_st  work2, MTX34._23(pOut), 1, 0
-    }
+    )
     // clang-format on
 
     return pOut;
@@ -330,7 +330,7 @@ MTX44* MTX44Identity(register MTX44* pMtx) {
     register f32 c_01, c_10;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         ps_merge01 c_01, c_zero, c_one
         ps_merge10 c_10, c_one, c_zero
 
@@ -342,7 +342,7 @@ MTX44* MTX44Identity(register MTX44* pMtx) {
         psq_st c_10,   MTX44._22(pMtx), 0, 0  // _22=1, _23=0
         psq_st c_zero, MTX44._30(pMtx), 0, 0  // _30=0, _31=0
         psq_st c_01,   MTX44._32(pMtx), 0, 0  // _32=0, _33=1
-    }
+    )
     // clang-format on
 
     return pMtx;
@@ -355,7 +355,7 @@ MTX44* MTX44Copy(register MTX44* pDst, register const MTX44* pSrc) {
     register f32 row3a, row3b;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         psq_l row0a, MTX44._00(pSrc), 0, 0
         psq_l row0b, MTX44._02(pSrc), 0, 0
         psq_l row1a, MTX44._10(pSrc), 0, 0
@@ -373,7 +373,7 @@ MTX44* MTX44Copy(register MTX44* pDst, register const MTX44* pSrc) {
         psq_st row2b, MTX44._22(pDst), 0, 0
         psq_st row3a, MTX44._30(pDst), 0, 0
         psq_st row3b, MTX44._32(pDst), 0, 0
-    }
+    )
     // clang-format on
 
     return pDst;

--- a/src/revolution/BASE/PPCArch.c
+++ b/src/revolution/BASE/PPCArch.c
@@ -129,10 +129,10 @@ asm void PPCMtpmc4(register u32 val){
 u32 PPCMffpscr(void) {
     // clang-format off
     register u64 fpscr;
-    asm {
+    PPC_ASM (
         mffs f31
         stfd f31, fpscr
-    }
+    )
 
     return fpscr;
     // clang-format on
@@ -145,13 +145,13 @@ void PPCMtfpscr(register u32 val) {
         f32 data;
     } fpscr;
 
-    asm {
+    PPC_ASM (
         li r4, 0
         stw val, fpscr.data
         stw r4, fpscr.tmp
         lfd f31, fpscr.tmp
         mtfs f31
-    }
+    )
     // clang-format on
 }
 
@@ -203,17 +203,17 @@ asm void PPCSetFpNonIEEEMode(void) {
 void PPCMthid4(register u32 val) {
     if (val & HID4_H4A) {
         // clang-format off
-        asm {
+        PPC_ASM (
             mtspr 0x3F3, val
-        }
+        )
         // clang-format on
     } else {
         OSReport("H4A should not be cleared because of Broadway errata.\n");
         val |= HID4_H4A;
         // clang-format off
-        asm {
+        PPC_ASM (
             mtspr 0x3F3, val
-        }
+        )
         // clang-format on
     }
 }

--- a/src/revolution/MTX/quat.c
+++ b/src/revolution/MTX/quat.c
@@ -14,7 +14,7 @@ void PSQUATMultiply(register const Quaternion* a, register const Quaternion* b,
     register f32 work1, work2, work3, work4, work5;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         // Load qA components
         psq_l axy, Quaternion.x(a), 0, 0 // AX, AY
         psq_l azw, Quaternion.z(a), 0, 0 // AZ, AW
@@ -47,7 +47,7 @@ void PSQUATMultiply(register const Quaternion* a, register const Quaternion* b,
         // Store result
         psq_st work1, Quaternion.x(prod), 0, 0
         psq_st work3, Quaternion.z(prod), 0, 0
-    }
+    )
     // clang-format on
 }
 
@@ -62,7 +62,7 @@ void PSQUATNormalize(register const Quaternion* in, register Quaternion* out) {
     c_three = 3.0f;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         // Load quaternion components
         psq_l xy, Quaternion.x(in), 0, 0
         psq_l zw, Quaternion.z(in), 0, 0
@@ -95,7 +95,7 @@ void PSQUATNormalize(register const Quaternion* in, register Quaternion* out) {
         // Store result
         psq_st xy, Quaternion.x(out), 0, 0
         psq_st zw, Quaternion.z(out), 0, 0
-    }
+    )
     // clang-format on
 }
 

--- a/src/revolution/MTX/vec.c
+++ b/src/revolution/MTX/vec.c
@@ -30,7 +30,7 @@ void PSVECScale(register const Vec* in, register Vec* out, register f32 scale) {
     register f32 sxy, sz;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         // Load components
         psq_l xy, Vec.x(in), 0, 0
         psq_l z,  Vec.z(in), 1, 0
@@ -42,7 +42,7 @@ void PSVECScale(register const Vec* in, register Vec* out, register f32 scale) {
         // Store result
         psq_st sxy, Vec.x(out), 0, 0
         psq_st sz,  Vec.z(out), 1, 0
-    }
+    )
     // clang-format on
 }
 
@@ -57,7 +57,7 @@ void PSVECNormalize(register const Vec* in, register Vec* out) {
     c_three = 3.0f;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         // Load vector components
         psq_l xy, Vec.x(in), 0, 0
         psq_l z,  Vec.z(in), 1, 0
@@ -84,7 +84,7 @@ void PSVECNormalize(register const Vec* in, register Vec* out) {
         // Store result
         psq_st xy, Vec.x(out), 0, 0
         psq_st z,  Vec.z(out), 1, 0
-    }
+    )
     // clang-format on
 }
 
@@ -98,7 +98,7 @@ f32 PSVECMag(register const Vec* v) {
 
     c_half = 0.5f;
     // clang-format off
-    asm {
+    PPC_ASM (
         // Load vector components
         psq_l xy, Vec.x(v), 0, 0
         lfs   z,  Vec.z(v)
@@ -110,7 +110,7 @@ f32 PSVECMag(register const Vec* v) {
 
         // Get zero
         fsubs c_zero, c_half, c_half
-    }
+    )
     // clang-format on
 
     // Avoid problematic square root where dot is zero
@@ -123,7 +123,7 @@ f32 PSVECMag(register const Vec* v) {
 
     c_three = 3.0f;
     // clang-format off
-    asm {
+    PPC_ASM (
         // Refine estimate using Newton-Raphson method
         // y = 1 / sqrt(x)
         fmuls   work0, rsqrt, rsqrt        // rsqrt^2
@@ -134,7 +134,7 @@ f32 PSVECMag(register const Vec* v) {
         // Convert rsqrt -> sqrt
         // x * rsqrt(x) == sqrt(x)
         fmuls dot, dot, work1
-    }
+    )
     // clang-format on
 
     return dot;
@@ -228,7 +228,7 @@ f32 PSVECSquareDistance(register const Vec* a, register const Vec* b) {
     register f32 dist;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         // Load vector components
         psq_l axy, Vec.x(a), 0, 0
         psq_l ayz, Vec.y(a), 0, 0 
@@ -243,7 +243,7 @@ f32 PSVECSquareDistance(register const Vec* a, register const Vec* b) {
         ps_mul  dyz,  dyz,  dyz
         ps_madd dist, dxy,  dxy, dyz
         ps_sum0 dist, dist, dyz, dyz
-    }
+    )
     // clang-format on
 
     return dist;

--- a/src/revolution/OS/OS.c
+++ b/src/revolution/OS/OS.c
@@ -851,7 +851,7 @@ void __OSPSInit(void) {
     ICFlashInvalidate();
 
     // clang-format off
-    asm {
+    PPC_ASM (
         sync
         li r3, 0
         mtgqr0 r3
@@ -862,7 +862,7 @@ void __OSPSInit(void) {
         mtgqr5 r3
         mtgqr6 r3
         mtgqr7 r3
-    }
+    )
     // clang-format on
 }
 

--- a/src/runtime/__init_cpp_exceptions.cpp
+++ b/src/runtime/__init_cpp_exceptions.cpp
@@ -17,9 +17,9 @@ static void* GetTOC(void) {
     register void* toc;
 
     // clang-format off
-    asm {
+    PPC_ASM (
         mr toc, r2
-    };
+    );
     // clang-format on
 
     return toc;

--- a/tools/project.py
+++ b/tools/project.py
@@ -1556,13 +1556,19 @@ def generate_compile_commands(
         "-i-",
     }
     CFLAG_IGNORE_PREFIX: Tuple[str, ...] = (
-        # Recursive includes are not supported by modern compilers
-        "-ir ",
+        # Recursive includes are not supported by modern compilers.
+        # Temporarily disabled, see `CFLAG_REPLACE_PREFIX` below.
+        # "-ir ",
     )
 
     # Flags to replace
     CFLAG_REPLACE: Dict[str, str] = {}
     CFLAG_REPLACE_PREFIX: Tuple[Tuple[str, str], ...] = (
+        # Recursive includes are not supported by modern compilers.
+        # This is a temporary workaround until recursive includes are phased out.
+        # Most headers will accept this, but some still rely on recursive headers. 
+        # Those will display flase errors.
+        ("-ir ", "-I"),
         # Includes
         ("-i ", "-I"),
         ("-I ", "-I"),


### PR DESCRIPTION
Improves navigating the repo using clangd as a language server. Clangd gives spurious errors about codewarrior's fixed address syntax like `volatile u16 VI_HW_REGS[] : 0xCC002000;`. It also doesn't like `asm` blocks. I copied some useful macros from rb3 to work around this: `AT_ADDRESS` and `PPC_ASM`. See: https://github.com/DarkRTA/rb3/blob/master/src/decomp.h#L71-L77 and https://github.com/DarkRTA/rb3/blob/94fc872b13b24acac25c7dcce0dcda008225ffef/doc/src-old/sdk/RVL_SDK/revolution/os/OSUtils.h#L13-L17.
I also temporarily configured the build system to emit `-I` in place of `-ir` since "Recursive includes are not supported by modern compilers" as dtk-template says. This works well enough, but it's not perfect.